### PR TITLE
Add missing `go install` part

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ languages.
 
 How to use the generator:
 
-    $ github.com/alecthomas/go-thrift/cmd/go-thrift
+    $ go install github.com/alecthomas/go-thrift/cmd/go-thrift
 
     $ go-thrift --help
     Usage of generator:


### PR DESCRIPTION
Somehow left out `go install` last time.

