### PR TITLE
Fix "bug" in the thrift decoder.

### DIFF
--- a/thrift/decoder.go
+++ b/thrift/decoder.go
@@ -205,6 +205,7 @@ func (d *decoder) readValue(thriftType byte, rf reflect.Value) {
 		if err != nil {
 			d.error(err)
 		}
+		v.Set(reflect.MakeSlice(reflect.SliceOf(elemType), 0, n))
 		for i := 0; i < n; i++ {
 			val := reflect.New(elemType)
 			d.readValue(et, val.Elem())
@@ -220,6 +221,7 @@ func (d *decoder) readValue(thriftType byte, rf reflect.Value) {
 			if err != nil {
 				d.error(err)
 			}
+			v.Set(reflect.MakeSlice(reflect.SliceOf(elemType), 0, n))
 			for i := 0; i < n; i++ {
 				val := reflect.New(elemType)
 				d.readValue(et, val.Elem())

--- a/thrift/decoder_test.go
+++ b/thrift/decoder_test.go
@@ -1,0 +1,42 @@
+package thrift
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestDecodeEmptyList checks that, when decoding a list, we get an empty slice
+// rather than a nil. While a nil and an empty list are often hard to tell apart
+// (e.g. len() gives the same result for them) they create problems downstream
+// (e.g. when serializing a struct using the go json package).
+//
+// One may be lured to think that it's possible to hide the issue just by adding
+// `json:omitempty` annotations to list fields (a common thing to do), so that the
+// nil values don't become json nulls. This works only on the surface, as e.g.
+// a list<list<i32>> clearly would have the problem - i.e. [[], [1,2]] would be
+// serialized as [null, [1,2]].
+func TestDecodeEmptyList(t *testing.T) {
+	buf := &bytes.Buffer{}
+	s := TestStruct{
+		List: []string{},
+	}
+	if len(s.List) != 0 || s.List == nil {
+		t.Fatal("Unexpected error")
+	}
+	err := EncodeStruct(NewBinaryProtocolWriter(buf, true), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := TestStruct{}
+	err = DecodeStruct(NewBinaryProtocolReader(buf, true), &d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.List) != 0 {
+		t.Fatalf("Decoding error - wrong length for d.List = %d (expected 0)", len(d.List))
+	}
+	if d.List == nil {
+		t.Fatal("Decoding error - d.List is nil (expected [])")
+	}
+}


### PR DESCRIPTION
Empty lists that are actually present in the protocol should be decoded as [], not as nil.

This typically does not matter because the accessor methods on a struct work the same on a nil slice an empty slice.
But it does matter if we re-serialize the struct using some different method, e.g. and most notably the go json package.

In that case, nil values would be presented as `null` rather than `[]` in the serialized json. The generated struct includes annotations on the fields (`omitempty`) that make so that this does not happen in most common cases (i.e. struct fields that are empty lists). Unfortunately it is not-too-hard to devise examples where these `null` values actually make it to the serialized json (e.g. using a list<list<int>>; if you were to decode [[1,2], []] this would later be encoded to json as [[1,2], null]).